### PR TITLE
Add Google Analytics event tracking for ads conversion

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -56,6 +56,13 @@ export default function DashboardLayout({
             gtag('config', 'AW-585954066');
           `}
         </Script>
+        <Script id="google-analytics-event" strategy="afterInteractive">
+          {`
+            gtag('event', 'ads_conversion___1', {
+              // <event_parameters>
+            });
+          `}
+        </Script>
       </head>
       <body className={notoSans.className}>
         <CartProvider>


### PR DESCRIPTION
- Introduced a new Google Analytics event script in the layout to track ads conversion events, enhancing data collection for marketing analysis.